### PR TITLE
Add an encoding which minimises the uses of chr using map

### DIFF
--- a/pyminify.py
+++ b/pyminify.py
@@ -4,8 +4,20 @@ import argparse
 import os
 import sys
 
+def encode_string_with_chr(data: str) -> str:
+	return "+".join([f"chr({ord(x)})" for x in data])
+
+def encode_string(data: str, using_map: bool) -> str:
+	if not using_map:
+		return encode_string_with_chr(data)
+
+	utf8_string = encode_string_with_chr('utf-8')
+	encoded_string = '[' + ','.join(map(lambda x: str(ord(x)),data)) + ']'
+	return f"str(bytes({encoded_string}),{utf8_string})"
+
 # Ensure that this includes an argument for the file
 parser = argparse.ArgumentParser()
+parser.add_argument('--use-map', action='store_true')
 parser.add_argument("script", type=str)
 args = parser.parse_args()
 
@@ -15,13 +27,8 @@ if not os.path.exists(args.script):
 with open(args.script, "rb") as h:
 	contents = h.read().decode('utf-8')
 
-code_string = "+".join([f"chr({ord(x)})" for x in contents])
-code_string = f"{code_string}"
+code_string = encode_string(contents, args.use_map)
+script_string = encode_string("<script>", args.use_map)
+exec_string = encode_string("exec", args.use_map)
 
-script_string = "+".join([f"chr({ord(x)})" for x in "<script>"])
-script_string = f"{script_string}"
-
-exec_string = "+".join([f"chr({ord(x)})" for x in "exec"])
-exec_string = f"{exec_string}"
-
-print(f'python -c "exec(compile({code_string}, {script_string}, {exec_string}))"')
+print(f'python -c "exec(compile({code_string},{script_string},{exec_string}))"')


### PR DESCRIPTION
I added an option to use map in the encoding which minimizes the usage of `chr` in the generated code.

You can pass the option `--use-map` and it will use map in the encoding. The resulting code has no spaces and quote. When using the map encoding, the string "utf-8" is encoded with `chr` to avoid using any kind of quotes.